### PR TITLE
Refactor tooltip styling

### DIFF
--- a/formate.css
+++ b/formate.css
@@ -341,6 +341,7 @@ select {
 
 /*** GALAXY PAGE ***/
 #galaxy_form #t1 table td.l { vertical-align: middle; }
+#galaxy_form + table > tbody > tr:nth-last-child(2) td:last-child { visibility: hidden; }
 
 /*** ALLIANCE PAGE ***/
 #content > center > img {

--- a/formate.css
+++ b/formate.css
@@ -101,7 +101,7 @@ select {
 
 #overDiv table[width="240"],
 #overDiv table[width="240"] + table,
-#overDiv font > table:not([width="240"]) {
+#overDiv font > table:not([width]) {
     width: 175px;
 }
 
@@ -112,11 +112,11 @@ select {
 }
 
 #overDiv table[width="240"] > tbody > tr:first-child,
-#overDiv font > table:not([width="240"]) tr:first-child {
+#overDiv font > table:not([width]) tr:first-child {
     border-bottom: 1px solid #36474f;
 }
 #overDiv table[width="240"] > tbody > tr:first-child > td.c,
-#overDiv font > table:not([width="240"]) tr:first-child td.c {
+#overDiv font > table:not([width]) tr:first-child td.c {
     padding: 5px;
     padding-top: 10px;
     background: #607D8B;
@@ -126,7 +126,7 @@ select {
     content: 'Debris field';
 }
 #overDiv table[width="240"] + table tr:first-child td::after,
-#overDiv font > table:not([width="240"]) tr:first-child td::after {
+#overDiv font > table:not([width]) tr:first-child td::after {
     content: ':';
 }
 
@@ -134,7 +134,7 @@ select {
 #overDiv table[width="240"] + table tr:not(:last-child),
 #overDiv table[width="240"] + table tr:last-child a:not(:last-of-type),
 #overDiv table[width="240"] th[width="80"] + th > a:not(:last-of-type),
-#overDiv font > table:not([width="240"]) tr:not(:last-child) {
+#overDiv font > table:not([width]) tr:not(:last-child) {
     border-bottom: 1px solid #36474f;
 }
 #overDiv table[width="240"] table tr td,
@@ -143,7 +143,7 @@ select {
 #overDiv table[width="240"] + table tr:not(:last-child) th,
 #overDiv table[width="240"] + table tr:last-child a,
 #overDiv table[width="240"] th[width="80"] + th > a,
-#overDiv font > table:not([width="240"]) td {
+#overDiv font > table:not([width]) td {
     padding: 5px;
 }
 
@@ -151,7 +151,7 @@ select {
 #overDiv table[width="240"] table tr:last-child th,
 #overDiv table[width="240"] + table tr:last-child th a:last-of-type,
 #overDiv table[width="240"] th[width="80"] + th > a:last-of-type,
-#overDiv font > table:not([width="240"]) tr:last-child td {
+#overDiv font > table:not([width]) tr:last-child td {
     padding-bottom: 10px;
 }
 

--- a/formate.css
+++ b/formate.css
@@ -59,13 +59,18 @@ select {
 
 /*** TOOLTIPS ***/
 #overDiv {
-    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+    padding: 5px 20px 20px 20px;
+    z-index: 1000;
 }
 
 #overDiv table {
-    width: 175px;
+    width: 100%;
     text-align: center;
     background: transparent !important;
+}
+#overDiv > table {
+    background: #263238 !important;
+    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
 }
 
 #overDiv td,
@@ -86,16 +91,32 @@ select {
     display: none;
 }
 
+#overDiv font > font {
+    display: block;
+    padding: 5px;
+    text-align: left;
+}
+#overDiv font > font b { font-weight: normal; }
+#overDiv font > font br { display: inline; }
+
+#overDiv table[width="240"],
+#overDiv table[width="240"] + table,
+#overDiv font > table:not([width="240"]) {
+    width: 175px;
+}
+
 #overDiv table[width="240"] th[width="80"],
 #overDiv table[width="240"] table > tbody > tr:nth-child(4),
 #overDiv table[width="240"] + table > tbody > tr:nth-child(4) {
     display: none;
 }
 
-#overDiv table[width="240"] > tbody > tr:first-child {
+#overDiv table[width="240"] > tbody > tr:first-child,
+#overDiv font > table:not([width="240"]) tr:first-child {
     border-bottom: 1px solid #36474f;
 }
-#overDiv table[width="240"] > tbody > tr:first-child > td.c {
+#overDiv table[width="240"] > tbody > tr:first-child > td.c,
+#overDiv font > table:not([width="240"]) tr:first-child td.c {
     padding: 5px;
     padding-top: 10px;
     background: #607D8B;
@@ -104,14 +125,16 @@ select {
 #overDiv table[width="240"] > tbody > tr:first-child > td.c:empty::after {
     content: 'Debris field';
 }
-#overDiv table[width="240"] + table tr:first-child td::after {
+#overDiv table[width="240"] + table tr:first-child td::after,
+#overDiv font > table:not([width="240"]) tr:first-child td::after {
     content: ':';
 }
 
 #overDiv table[width="240"] table tr:not(:last-child),
 #overDiv table[width="240"] + table tr:not(:last-child),
 #overDiv table[width="240"] + table tr:last-child a:not(:last-of-type),
-#overDiv table[width="240"] th[width="80"] + th > a:not(:last-of-type) {
+#overDiv table[width="240"] th[width="80"] + th > a:not(:last-of-type),
+#overDiv font > table:not([width="240"]) tr:not(:last-child) {
     border-bottom: 1px solid #36474f;
 }
 #overDiv table[width="240"] table tr td,
@@ -119,15 +142,16 @@ select {
 #overDiv table[width="240"] + table tr:not(:last-child) td,
 #overDiv table[width="240"] + table tr:not(:last-child) th,
 #overDiv table[width="240"] + table tr:last-child a,
-#overDiv table[width="240"] th[width="80"] + th > a {
+#overDiv table[width="240"] th[width="80"] + th > a,
+#overDiv font > table:not([width="240"]) td {
     padding: 5px;
-    background: #263238;
 }
 
 #overDiv table[width="240"] table tr:last-child td,
 #overDiv table[width="240"] table tr:last-child th,
 #overDiv table[width="240"] + table tr:last-child th a:last-of-type,
-#overDiv table[width="240"] th[width="80"] + th > a:last-of-type {
+#overDiv table[width="240"] th[width="80"] + th > a:last-of-type,
+#overDiv font > table:not([width="240"]) tr:last-child td {
     padding-bottom: 10px;
 }
 
@@ -341,7 +365,6 @@ select {
 
 /*** GALAXY PAGE ***/
 #galaxy_form #t1 table td.l { vertical-align: middle; }
-#galaxy_form + table > tbody > tr:nth-last-child(2) td:last-child { visibility: hidden; }
 
 /*** ALLIANCE PAGE ***/
 #content > center > img {
@@ -352,6 +375,9 @@ select {
 }
 
 #content > center > a { display: block; }
+
+/*** ALLIANCE PAGE ***/
+#content form[action*="page=stat"] + table th:first-child a[href="#"] { text-decoration: none; }
 
 /*** MESSAGES PAGE ***/
 input[type="checkbox"] + input[value="REPORT MESSAGE"] {

--- a/formate.css
+++ b/formate.css
@@ -376,7 +376,7 @@ select {
 
 #content > center > a { display: block; }
 
-/*** ALLIANCE PAGE ***/
+/*** STATISTICS PAGE ***/
 #content form[action*="page=stat"] + table th:first-child a[href="#"] { text-decoration: none; }
 
 /*** MESSAGES PAGE ***/

--- a/formate.css
+++ b/formate.css
@@ -62,66 +62,70 @@ select {
     box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
 }
 
+#overDiv table {
+    width: 175px;
+    text-align: center;
+    background: transparent !important;
+}
+
 #overDiv td,
 #overDiv th {
-    background-color: #263238;
-    border: 0;
+    padding: 0;
+    border: 0 none;
+    background: transparent;
     font-weight: normal;
-    padding: 5px 0px;
 }
 
 #overDiv a {
-    color: #607D8B;
-    cursor: auto;
     display: block;
-    font-weight: bold;
-    padding: 5px 0px;
+    color: #607D8B;
+    cursor: pointer;
 }
 
-#overDiv a:first-child {
-    padding-top: 0;
-}
-
-#overDiv a:last-child {
-    padding-bottom: 0;
-}
-
-#overDiv a:not(:last-child) {
-    border-bottom: 1px solid #36474f;
-}
-
-#overDiv a:nth-child(8) {
-    border-bottom: 0;
-    padding-bottom: 0;
-}
-
-#overDiv a + br, #overDiv br + br {
+#overDiv br {
     display: none;
 }
 
-#overDiv table {
-    width: 150px;
-    text-align: center;
-}
-
-#overDiv > table > tbody > tr > td {
-    padding: 0;
-}
-
-#overDiv table table table table tr {
-    border-top: 1px solid #36474f;
-}
-
-#overDiv > table table table th[width="80"] {
+#overDiv table[width="240"] th[width="80"],
+#overDiv table[width="240"] table > tbody > tr:nth-child(4),
+#overDiv table[width="240"] + table > tbody > tr:nth-child(4) {
     display: none;
 }
 
-#overDiv table table table:first-child > tbody > tr:first-child > td {
-    text-align: center;
+#overDiv table[width="240"] > tbody > tr:first-child {
+    border-bottom: 1px solid #36474f;
+}
+#overDiv table[width="240"] > tbody > tr:first-child > td.c {
+    padding: 5px;
+    padding-top: 10px;
+    background: #607D8B;
 }
 
-#overDiv table table table tr:not(:last-child) {
+#overDiv table[width="240"] > tbody > tr:first-child > td.c:empty::after {
+    content: 'Debris field';
+}
+#overDiv table[width="240"] + table tr:first-child td::after {
+    content: ':';
+}
+
+#overDiv table[width="240"] table tr:not(:last-child),
+#overDiv table[width="240"] + table tr:not(:last-child), 
+#overDiv table[width="240"] + table tr:last-child a:not(:last-of-type) {
     border-bottom: 1px solid #36474f;
+}
+#overDiv table[width="240"] table tr td,
+#overDiv table[width="240"] table tr th,
+#overDiv table[width="240"] + table tr:not(:last-child) td,
+#overDiv table[width="240"] + table tr:not(:last-child) th,
+#overDiv table[width="240"] + table tr:last-child a {
+    padding: 5px;
+    background: #263238;
+}
+
+#overDiv table[width="240"] table tr:last-child td,
+#overDiv table[width="240"] table tr:last-child th,
+#overDiv table[width="240"] + table tr:last-child th a:last-of-type {
+    padding-bottom: 10px;
 }
 
 /*** HEADER ***/

--- a/formate.css
+++ b/formate.css
@@ -95,6 +95,7 @@ select {
     display: block;
     padding: 5px;
     text-align: left;
+    font-size: 1.1rem;
 }
 #overDiv font > font b { font-weight: normal; }
 #overDiv font > font br { display: inline; }
@@ -439,7 +440,7 @@ font[color="#00ff00"], font[color="00FF00"], font[color="lime"], .noob { color: 
     }
 
     #menu > table div font a {
-        font-size: 14px;
+        font-size: 1.1rem;
         padding: 10px;
     }
 

--- a/formate.css
+++ b/formate.css
@@ -109,22 +109,25 @@ select {
 }
 
 #overDiv table[width="240"] table tr:not(:last-child),
-#overDiv table[width="240"] + table tr:not(:last-child), 
-#overDiv table[width="240"] + table tr:last-child a:not(:last-of-type) {
+#overDiv table[width="240"] + table tr:not(:last-child),
+#overDiv table[width="240"] + table tr:last-child a:not(:last-of-type),
+#overDiv table[width="240"] th[width="80"] + th > a:not(:last-of-type) {
     border-bottom: 1px solid #36474f;
 }
 #overDiv table[width="240"] table tr td,
 #overDiv table[width="240"] table tr th,
 #overDiv table[width="240"] + table tr:not(:last-child) td,
 #overDiv table[width="240"] + table tr:not(:last-child) th,
-#overDiv table[width="240"] + table tr:last-child a {
+#overDiv table[width="240"] + table tr:last-child a,
+#overDiv table[width="240"] th[width="80"] + th > a {
     padding: 5px;
     background: #263238;
 }
 
 #overDiv table[width="240"] table tr:last-child td,
 #overDiv table[width="240"] table tr:last-child th,
-#overDiv table[width="240"] + table tr:last-child th a:last-of-type {
+#overDiv table[width="240"] + table tr:last-child th a:last-of-type,
+#overDiv table[width="240"] th[width="80"] + th > a:last-of-type {
     padding-bottom: 10px;
 }
 


### PR DESCRIPTION
Oh yeah, the underlying HTML is really awful... I've tried to refactor your tooltip styling a bit to make it more readable. Are the four tooltips of the galaxy page (player, alliance, moon, DF) really the only ones or are there more?

You can use http://phrozenbyte.com/ogame-retro-skins/use/material_blue_grey/ to try this PR and #3.

![bildschirmfoto von 2016-06-11 02 07 12](https://cloud.githubusercontent.com/assets/920356/15981687/730b12ca-2f79-11e6-9282-ba182ba24ea1.png)

![bildschirmfoto von 2016-06-11 02 07 24](https://cloud.githubusercontent.com/assets/920356/15981679/5c605378-2f79-11e6-8b51-a11b48a45b06.png)

![bildschirmfoto von 2016-06-11 02 06 56](https://cloud.githubusercontent.com/assets/920356/15981684/6c574d0e-2f79-11e6-978c-60fe40de97d5.png)

![bildschirmfoto von 2016-06-11 02 06 41](https://cloud.githubusercontent.com/assets/920356/15981678/5c604496-2f79-11e6-85c2-855540b701d8.png)

Resolves #2
