### PR TITLE
Add event colors

### DIFF
--- a/formate.css
+++ b/formate.css
@@ -363,7 +363,7 @@ select {
 .ownfederation, .federation { color: #D43635; }
 .ownhold, .hold { color: #D57936; }
 .ownmissle, .missle { color: #D43635; }
-.return { opacity: 0.80; }
+.return { opacity: 0.70; }
 
 /*** RESOURCES PAGE ***/
 #ressourcen { margin-top: 0.5em; }

--- a/formate.css
+++ b/formate.css
@@ -352,6 +352,19 @@ select {
     width: 14px;
 }
 
+/*** EVENTS ***/
+.owncolony { color: #2BBFBF; }
+.owntransport, .transport { color: #7EAD3D; }
+.owndeploy, .deploy { color: #36B588; }
+.ownespionage, .espionage { color: #BD9B2F; }
+.ownattack, .attack { color: #D43635; }
+.owndestroy, .destroy { color: #FF3356; }
+.ownharvest { color: #11A140; }
+.ownfederation, .federation { color: #D43635; }
+.ownhold, .hold { color: #D57936; }
+.ownmissle, .missle { color: #D43635; }
+.return { opacity: 0.80; }
+
 /*** RESOURCES PAGE ***/
 #ressourcen { margin-top: 0.5em; }
 #ressourcen font[color="#FFFFFF"] { color: #ECEFF1; }

--- a/formate.css
+++ b/formate.css
@@ -356,8 +356,8 @@ select {
 .owncolony { color: #2BBFBF; }
 .owntransport, .transport { color: #7EAD3D; }
 .owndeploy, .deploy { color: #36B588; }
-.ownespionage, .espionage { color: #BD9B2F; }
-.ownattack, .attack { color: #D43635; }
+.ownespionage, .espionage, .espionagereport { color: #BD9B2F; }
+.ownattack, .attack, .combatreport { color: #D43635; }
 .owndestroy, .destroy { color: #FF3356; }
 .ownharvest { color: #11A140; }
 .ownfederation, .federation { color: #D43635; }


### PR DESCRIPTION
OGame's default event (fleet activity) colors aren't very useful... This PR adds custom colors, borrowed from AntiGameOrigin v6.
